### PR TITLE
Fixed role assignment in code samples

### DIFF
--- a/articles/key-vault/certificates/create-certificate.md
+++ b/articles/key-vault/certificates/create-certificate.md
@@ -78,7 +78,7 @@ When a request to create a KV certificate completes, the status of the pending o
 Certificate creation can be completed manually or using a "Self" issuer. Key Vault also partners with certain issuer providers to simplify the creation of certificates. The following types of certificates can be ordered for key vault with these partner issuer providers.  
 
 |Provider|Certificate type|Configuration setup  
-|--------------|----------------------|------------------|  
+|--------------|----------------------|------------------|
 |DigiCert|Key Vault offers OV or EV SSL certificates with DigiCert| [Integration Guide](./how-to-integrate-certificate-authority.md)
 |GlobalSign|Key Vault offers OV or EV SSL certificates with GlobalSign| [Integration Guide](https://support.globalsign.com/code-signing/Code-Signing-certificate-setup-in-Azure-Key-vault)
 

--- a/articles/key-vault/certificates/quick-create-go.md
+++ b/articles/key-vault/certificates/quick-create-go.md
@@ -44,13 +44,13 @@ Follow this guide to learn how to use the [azcertificates](https://aka.ms/azsdk/
 
 [!INCLUDE [Create a resource group and key vault](../includes/key-vault-rg-kv-creation.md)]
 
-#### Grant access to your key vault
+### Grant access to your key vault
 
 [!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-certificate-officer-cli.md)]
 
-#### Set environment variables
+### Create a new Go module and install packages
 
-Create a new Go module and install packages
+Run the following Go commands:
 
     ```azurecli
     go mod init quickstart-go-kvcerts

--- a/articles/key-vault/certificates/quick-create-go.md
+++ b/articles/key-vault/certificates/quick-create-go.md
@@ -25,30 +25,32 @@ Follow this guide to learn how to use the [azcertificates](https://aka.ms/azsdk/
 - **Go installed**: Version 1.18 or [above](https://go.dev/dl/)
 - [Azure CLI](/cli/azure/install-azure-cli)
 
-## Set up your environment
+### Sign in to the Azure portal
 
-
-1. Sign into Azure.
+1. In the Azure CLI, run the following command:
 
     ```azurecli
     az login
     ```
 
-1. Create a new resource group.
+    If the Azure CLI can open your default browser, it will do so on the Azure portal sign-in page.
 
-    ```azurecli
-    az group create --name myResourceGroup  --location eastus
-    ```
+    If the page doesn't open automatically, go to [https://aka.ms/devicelogin](https://aka.ms/devicelogin), and then enter the authorization code that's displayed in your terminal.
 
-1. Deploy a new key vault instance.
+1. Sign in to the Azure portal with your account credentials.
 
-    ```azurecli
-    az keyvault create --name <keyVaultName> --resource-group myResourceGroup
-    ```
 
-    Replace `<keyVaultName>` with a name that's unique across all of Azure. You typically use your personal or company name along with other numbers and identifiers.
+### Create a resource group and key vault
 
-1. Create a new Go module and install packages
+[!INCLUDE [Create a resource group and key vault](../includes/key-vault-rg-kv-creation.md)]
+
+#### Grant access to your key vault
+
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-certificate-officer-cli.md)]
+
+#### Set environment variables
+
+Create a new Go module and install packages
 
     ```azurecli
     go mod init quickstart-go-kvcerts

--- a/articles/key-vault/certificates/quick-create-java.md
+++ b/articles/key-vault/certificates/quick-create-java.md
@@ -119,7 +119,7 @@ Open the *pom.xml* file in your text editor. Add the following dependency elemen
 
 #### Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-certificate-officer-cli.md)]
 
 #### Set environment variables
 

--- a/articles/key-vault/certificates/quick-create-net.md
+++ b/articles/key-vault/certificates/quick-create-net.md
@@ -53,7 +53,7 @@ This quickstart is using Azure Identity library with Azure CLI to authenticate u
 
 ### Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-certificate-officer-cli.md)]
 
 ### Create new .NET console app
 

--- a/articles/key-vault/certificates/quick-create-node.md
+++ b/articles/key-vault/certificates/quick-create-node.md
@@ -98,7 +98,7 @@ Create a Node.js application that uses your key vault.
 
 ## Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-certificate-officer-cli.md)]
 
 ## Set environment variables
 

--- a/articles/key-vault/certificates/quick-create-python.md
+++ b/articles/key-vault/certificates/quick-create-python.md
@@ -90,7 +90,7 @@ This quickstart uses the Azure Identity library with Azure CLI or Azure PowerShe
 
 ### Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-certificate-officer-cli.md)]
 
 ## Create the sample code
 

--- a/articles/key-vault/keys/quick-create-go.md
+++ b/articles/key-vault/keys/quick-create-go.md
@@ -44,12 +44,14 @@ Follow this guide to learn how to use the [azkeys](https://aka.ms/azsdk/go/keyva
 
 [!INCLUDE [Create a resource group and key vault](../includes/key-vault-rg-kv-creation.md)]
 
-#### Grant access to your key vault
+### Grant access to your key vault
 
 [!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-crypto-officer-cli.md)]
 
 
-1. Create a new Go module and install packages
+### Create a new Go module and install packages
+
+Run the following Go commands:
 
     ```azurecli
     go mod init quickstart-keys

--- a/articles/key-vault/keys/quick-create-go.md
+++ b/articles/key-vault/keys/quick-create-go.md
@@ -26,27 +26,28 @@ Follow this guide to learn how to use the [azkeys](https://aka.ms/azsdk/go/keyva
 - [Azure CLI](/cli/azure/install-azure-cli)
 
 
-## Set up your environment
+### Sign in to the Azure portal
 
-1. Sign into Azure.
+1. In the Azure CLI, run the following command:
 
     ```azurecli
     az login
     ```
 
-1. Create a new resource group.
+    If the Azure CLI can open your default browser, it will do so on the Azure portal sign-in page.
 
-    ```azurecli
-    az group create --name quickstart-rg --location eastus
-    ```
+    If the page doesn't open automatically, go to [https://aka.ms/devicelogin](https://aka.ms/devicelogin), and then enter the authorization code that's displayed in your terminal.
 
-1. Deploy a new key vault instance.
+1. Sign in to the Azure portal with your account credentials.
 
-    ```azurecli
-    az keyvault create --name <keyVaultName> --resource-group quickstart-rg
-    ```
+### Create a resource group and key vault
 
-    Replace `<keyVaultName>` with a name that's unique across all of Azure. You typically use your personal or company name along with other numbers and identifiers.
+[!INCLUDE [Create a resource group and key vault](../includes/key-vault-rg-kv-creation.md)]
+
+#### Grant access to your key vault
+
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-crypto-officer-cli.md)]
+
 
 1. Create a new Go module and install packages
 

--- a/articles/key-vault/keys/quick-create-java.md
+++ b/articles/key-vault/keys/quick-create-java.md
@@ -115,7 +115,7 @@ Open the *pom.xml* file in your text editor. Add the following dependency elemen
 
 #### Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-crypto-officer-cli.md)]
 
 #### Set environment variables
 

--- a/articles/key-vault/keys/quick-create-net.md
+++ b/articles/key-vault/keys/quick-create-net.md
@@ -53,7 +53,7 @@ This quickstart is using Azure Identity library with Azure CLI to authenticate u
 
 #### Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-crypto-officer-cli.md)]
 
 ### Create new .NET console app
 

--- a/articles/key-vault/keys/quick-create-node.md
+++ b/articles/key-vault/keys/quick-create-node.md
@@ -99,7 +99,7 @@ Create a Node.js application that uses your key vault.
 
 ## Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-crypto-officer-cli.md)]
 
 ## Set environment variables
 

--- a/articles/key-vault/keys/quick-create-python.md
+++ b/articles/key-vault/keys/quick-create-python.md
@@ -90,7 +90,7 @@ This quickstart is using the Azure Identity library with Azure CLI or Azure Powe
 
 ### Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-crypto-officer-cli.md)]
 
 ## Create the sample code
 

--- a/articles/key-vault/secrets/quick-create-go.md
+++ b/articles/key-vault/secrets/quick-create-go.md
@@ -47,7 +47,7 @@ For purposes of this quickstart, you use the [azidentity](https://pkg.go.dev/git
 
 [!INCLUDE [Create a resource group and key vault](../includes/key-vault-rg-kv-creation.md)]
 
-#### Grant access to your key vault
+### Grant access to your key vault
 
 [!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-secrets-officer-cli.md)]
 

--- a/articles/key-vault/secrets/quick-create-go.md
+++ b/articles/key-vault/secrets/quick-create-go.md
@@ -43,15 +43,13 @@ For purposes of this quickstart, you use the [azidentity](https://pkg.go.dev/git
 
 1. Sign in to the Azure portal with your account credentials.
 
-### Create a resource group and key vault instance
+### Create a resource group and key vault
 
-Run the following Azure CLI commands:
+[!INCLUDE [Create a resource group and key vault](../includes/key-vault-rg-kv-creation.md)]
 
-```azurecli
-az group create --name quickstart-rg --location eastus
-az keyvault create --name quickstart-kv --resource-group quickstart-rg
-```
-Key Vault names are globally unique so it is possible that the name is already taken. You may need to choose a unique value for your Key Vault name.
+#### Grant access to your key vault
+
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-secrets-officer-cli.md)]
 
 ### Create a new Go module and install packages
 

--- a/articles/key-vault/secrets/quick-create-java.md
+++ b/articles/key-vault/secrets/quick-create-java.md
@@ -118,7 +118,7 @@ Open the *pom.xml* file in your text editor. Add the following dependency elemen
 
 #### Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-secrets-officer-cli.md)]
 
 #### Set environment variables
 

--- a/articles/key-vault/secrets/quick-create-net.md
+++ b/articles/key-vault/secrets/quick-create-net.md
@@ -55,7 +55,7 @@ This quickstart is using Azure Identity library with Azure CLI to authenticate u
 
 ### Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-secrets-officer-cli.md)]
 
 ### [Azure PowerShell](#tab/azure-powershell)
 

--- a/articles/key-vault/secrets/quick-create-node.md
+++ b/articles/key-vault/secrets/quick-create-node.md
@@ -101,7 +101,7 @@ Create a Node.js application that uses your key vault.
 
 ## Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-secrets-officer-cli.md)]
 
 ## Set environment variables
 

--- a/articles/key-vault/secrets/quick-create-python.md
+++ b/articles/key-vault/secrets/quick-create-python.md
@@ -89,7 +89,7 @@ This quickstart is using Azure Identity library with Azure CLI or Azure PowerShe
 
 ### Grant access to your key vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-secrets-officer-cli.md)]
 
 ## Create the sample code
 


### PR DESCRIPTION
The role assignments are wrong in all code samples.
For creating a new key, secret, and certificate; the user's role must be  "Key Vault Officer" roles, not "Key Vault User"!
"Key Vault User" is just for read access, not write access.
