### PR TITLE
Updates title of rbac-guide.md

### DIFF
--- a/articles/key-vault/general/rbac-guide.md
+++ b/articles/key-vault/general/rbac-guide.md
@@ -11,7 +11,7 @@ ms.date: 04/04/2024
 ms.author: mbaldwin
 ---
 
-# Provide access to Key Vault keys, certificates, and secrets with an Azure role-based access control
+# Provide access to Key Vault keys, certificates, and secrets with Azure role-based access control
 
 > [!NOTE]
 > Key Vault resource provider supports two resource types: **vaults** and **managed HSMs**. Access control described in this article only applies to **vaults**. To learn more about access control for managed HSM, see [Managed HSM access control](../managed-hsm/access-control.md).


### PR DESCRIPTION
Dropped "a" from the title.

RBAC is an acronym and a term. Hence, no indefinite article ("a") is needed.

See [other articles about Azure RBAC](https://www.google.com/search?q=Azure+role-based+access+contro) as an example.

More specifically, [What is Azure role-based access control (Azure RBAC)?](https://learn.microsoft.com/en-us/azure/role-based-access-control/overview) doesn't use any articles (whether definite or indefinite) anywhere in the articl.