### PR TITLE
Remove Typo Error In Azure CLI

### DIFF
--- a/articles/key-vault/general/move-subscription.md
+++ b/articles/key-vault/general/move-subscription.md
@@ -89,7 +89,7 @@ Connect-AzAccount                                                          #Log 
 
 ```azurecli
 az account set -s <your-subscriptionId>                                    # Select your Azure Subscription
-$tenantId=$(az account show --query tenantId)                               # Get your tenantId
+tenantId=$(az account show --query tenantId)                               # Get your tenantId
 az keyvault update -n myvault --remove Properties.accessPolicies           # Remove the access policies
 az keyvault update -n myvault --set Properties.tenantId=$tenantId          # Update the key vault tenantId
 ```


### PR DESCRIPTION
$ is used in variable declaration and remove Typo Error In Azure CLI