### PR TITLE
Update how-to-integrate-certificate-authority.md for CertCentral divisions missing support

### DIFF
--- a/articles/key-vault/certificates/how-to-integrate-certificate-authority.md
+++ b/articles/key-vault/certificates/how-to-integrate-certificate-authority.md
@@ -44,8 +44,11 @@ Make sure you have the following information from your DigiCert CertCentral acco
 -	CertCentral account ID
 -	Organization ID
 -	API key
--   Account ID
--   Account Password
+-  Account ID
+-  Account Password
+
+    > [!WARNING]
+    > CertCentral Divisions are not supported and may result in a "_required_param:container_id and Message Division ID is a required parameter._" error when renewing or generating a new certificate. Make sure your CertCentral account does not make use of such feature.
 
 #### GlobalSign
 


### PR DESCRIPTION
CertCentral divisions are not supported using the Key Vault integration, resulting consistently in an error. Docs have been updated to reflect this problem.