### PR TITLE
Update enable-defender-for-endpoint.md

### DIFF
--- a/articles/defender-for-cloud/enable-defender-for-endpoint.md
+++ b/articles/defender-for-cloud/enable-defender-for-endpoint.md
@@ -192,6 +192,9 @@ To generate a benign test alert from Defender for Endpoint, select the tab for t
 
 ### Test on Windows
 
+> [!NOTE]
+> During the onboarding process, the Defender for Cloud extension deploys an agent on each Windows server, which automatically generates a self‑signed certificate named Microsoft.Azure.AzureDefenderForServers.MDE.Windows. This certificate is used to secure and authenticate communication between the server and Defender for Endpoint. Importantly, the certificate is auto‑renewed by the agent without manual intervention. To ensure continuous protection, it is recommended that monitoring focuses on verifying that a valid certificate is present rather than tracking the expiration dates of individual certificates.
+
 For endpoints running Windows:
 
 1. Create a folder 'C:\test-MDATP-test'.


### PR DESCRIPTION
This addition clarifies both the purpose of the certificate and why administrators generally don’t need to monitor its expiration manually. It also suggests a best practice of ensuring the overall integration health is monitored so that any issues with auto-renewal can be caught indirectly.