### PR TITLE
Adjust RBAC scope best-practices for SSH private keys

### DIFF
--- a/articles/key-vault/general/rbac-guide.md
+++ b/articles/key-vault/general/rbac-guide.md
@@ -20,7 +20,7 @@ Azure role-based access control (Azure RBAC) is an authorization system built on
 
 Azure RBAC allows users to manage keys, secrets, and certificates permissions, and provides one place to manage all permissions across all key vaults.
 
-The Azure RBAC model allows users to set permissions on different scope levels: management group, subscription, resource group, or individual resources.  Azure RBAC for key vault also allows users to have separate permissions on individual keys, secrets, and certificates.
+The Azure RBAC model allows users to set permissions on different scope levels: management group, subscription, resource group, or individual resources. Azure RBAC for key vault also allows users to have separate permissions on individual keys, secrets, and certificates.
 
 For more information, see [Azure role-based access control (Azure RBAC)](/azure/role-based-access-control/overview).
 
@@ -44,14 +44,14 @@ More about Azure Key Vault management guidelines, see:
 
 | Built-in role | Description | ID |
 | --- | --- | --- |
-| Key Vault Administrator| Perform all data plane operations on a key vault and  all objects in it, including certificates, keys, and secrets. Cannot manage key vault resources or manage role assignments. Only works for key vaults that use the 'Azure role-based access control' permission model. | 00482a5a-887f-4fb3-b363-3b7fe8e74483 |
+| Key Vault Administrator| Perform all data plane operations on a key vault and all objects in it, including certificates, keys, and secrets. Cannot manage key vault resources or manage role assignments. Only works for key vaults that use the 'Azure role-based access control' permission model. | 00482a5a-887f-4fb3-b363-3b7fe8e74483 |
 | Key Vault Reader | Read metadata of key vaults and its certificates, keys, and secrets. Cannot read sensitive values such as secret contents or key material. Only works for key vaults that use the 'Azure role-based access control' permission model. | 21090545-7ca7-4776-b22c-e363652d74d2 |
 | Key Vault Purge Operator | Allows permanent deletion of soft-deleted vaults. | a68e7c17-0ab2-4c09-9a58-125dae29748c |
 | Key Vault Certificates Officer | Perform any action on the certificates of a key vault, except managing permissions. Only works for key vaults that use the 'Azure role-based access control' permission model. | a4417e6f-fecd-4de8-b567-7b0420556985 |
 | Key Vault Certificate User | Read entire certificate contents including secret and key portion. Only works for key vaults that use the 'Azure role-based access control' permission model. | db79e9a7-68ee-4b58-9aeb-b90e7c24fcba |
 | Key Vault Crypto Officer | Perform any action on the keys of a key vault, except manage permissions. Only works for key vaults that use the 'Azure role-based access control' permission model. | 14b46e9e-c2b7-41b4-b07b-48a6ebf60603 |
 | Key Vault Crypto Service Encryption User | Read metadata of keys and perform wrap/unwrap operations. Only works for key vaults that use the 'Azure role-based access control' permission model. | e147488a-f6f5-4113-8e2d-b22465e65bf6 |
-| Key Vault Crypto User  | Perform cryptographic operations using keys. Only works for key vaults that use the 'Azure role-based access control' permission model. | 12338af0-0e69-4776-bea7-57ae8d297424 |
+| Key Vault Crypto User | Perform cryptographic operations using keys. Only works for key vaults that use the 'Azure role-based access control' permission model. | 12338af0-0e69-4776-bea7-57ae8d297424 |
 | Key Vault Crypto Service Release User | Release keys for [Azure Confidential Computing](/azure/confidential-computing/concept-skr-attestation) and equivalent environments. Only works for key vaults that use the 'Azure role-based access control' permission model.
 | Key Vault Secrets Officer | Perform any action on the secrets of a key vault, except manage permissions. Only works for key vaults that use the 'Azure role-based access control' permission model. | b86a8fe4-44ce-4948-aee5-eccb2c155cd7 |
 | Key Vault Secrets User | Read secret contents including secret portion of a certificate with private key. Only works for key vaults that use the 'Azure role-based access control' permission model. | 4633458b-17de-408a-b874-0445c86b69e6 |
@@ -121,7 +121,7 @@ For full details, see [Assign Azure roles using Azure PowerShell](/azure/role-ba
 
 # [Azure portal](#tab/azure-portal)
 
-To assign roles using the Azure portal, see [Assign Azure roles using the Azure portal](/azure/role-based-access-control/role-assignments-portal).  In the Azure portal, the Azure role assignments screen is available for all resources on the Access control (IAM) tab.
+To assign roles using the Azure portal, see [Assign Azure roles using the Azure portal](/azure/role-based-access-control/role-assignments-portal). In the Azure portal, the Azure role assignments screen is available for all resources on the Access control (IAM) tab.
 
 ---
 
@@ -300,17 +300,15 @@ For full details, see [Assign Azure roles using Azure PowerShell](/azure/role-ba
 
 ```azurecli
 az role definition create --role-definition '{ \
-   "Name": "Backup Keys Operator", \
-   "Description": "Perform key backup/restore operations", \
-    "Actions": [ 
-    ], \
+    "Name": "Backup Keys Operator", \
+    "Description": "Perform key backup/restore operations", \
+    "Actions": [], \
     "DataActions": [ \
         "Microsoft.KeyVault/vaults/keys/read ", \
         "Microsoft.KeyVault/vaults/keys/backup/action", \
-         "Microsoft.KeyVault/vaults/keys/restore/action" \
+        "Microsoft.KeyVault/vaults/keys/restore/action" \
     ], \
-    "NotDataActions": [ 
-   ], \
+    "NotDataActions": [], \
     "AssignableScopes": ["/subscriptions/{subscriptionId}"] \
 }'
 ```
@@ -320,17 +318,15 @@ az role definition create --role-definition '{ \
 ```azurepowershell
 $roleDefinition = @"
 { 
-   "Name": "Backup Keys Operator", 
-   "Description": "Perform key backup/restore operations", 
-    "Actions": [ 
-    ], 
+    "Name": "Backup Keys Operator", 
+    "Description": "Perform key backup/restore operations", 
+    "Actions": [], 
     "DataActions": [ 
         "Microsoft.KeyVault/vaults/keys/read ", 
         "Microsoft.KeyVault/vaults/keys/backup/action", 
-         "Microsoft.KeyVault/vaults/keys/restore/action" 
+        "Microsoft.KeyVault/vaults/keys/restore/action" 
     ], 
-    "NotDataActions": [ 
-   ], 
+    "NotDataActions": [], 
     "AssignableScopes": ["/subscriptions/{subscriptionId}"] 
 }
 "@

--- a/articles/key-vault/general/rbac-guide.md
+++ b/articles/key-vault/general/rbac-guide.md
@@ -28,7 +28,9 @@ For more information, see [Azure role-based access control (Azure RBAC)](/azure/
 
 Our recommendation is to use a vault per application per environment (Development, Pre-Production, and Production) with roles assigned at the key vault scope.
 
-Assigning roles on individual keys, secrets and certificates should be avoided. An exception is a scenario where individual secrets must be shared between multiple applications; for example, where one application needs to access data from another application.
+Assigning roles on individual keys, secrets and certificates is not recommended. Exceptions include scenarios where:
+- individual secrets must be accessed by individual users; for example, where users must read their SSH private key to authenticate to a virtual machine using [Azure Bastion](/azure/bastion/bastion-overview).
+- individual secrets must be shared between multiple applications; for example, where one application needs to access data from another application.
 
 More about Azure Key Vault management guidelines, see:
 


### PR DESCRIPTION
This suggestion expends the list of exception to include user-scoped roles for reading individual private SSH key from Bastion UI.

This scenario allows cloud administrators to use of a single instance of Key Vault to centrally manage users' private SSH keys, while restricting access to individual keys to said users using Azure RBAC.

This is useful in situations where having a local copy of the private key isn't desired (e.g. for users with decentralized access).

![image](https://github.com/user-attachments/assets/d02160b5-dffe-4868-9523-4085e8f46cb1)
