### PR TITLE
Update file-integrity-monitoring-review-changes.md

### DIFF
--- a/articles/defender-for-cloud/file-integrity-monitoring-review-changes.md
+++ b/articles/defender-for-cloud/file-integrity-monitoring-review-changes.md
@@ -53,8 +53,8 @@ The file integrity monitoring data resides within the Azure Log Analytics worksp
     ```kusto  
     MDCFileIntegrityMonitoringEvents  
     | where TimeGenerated > ago(14d)  
-    | where ConfigChangeType in ('Registry', 'Files')  
-    | summarize count() by Computer, ConfigChangeType  
+    | where MonitoredEntityType in ('Registry', 'Files')  
+    | summarize count() by Computer, MonitoredEntityType, ChangeType  
     ```
 
 1. To view detailed information about registry changes:  


### PR DESCRIPTION
Based on the public documentation below, we have confirmed that the MDCFileIntegrityMonitoringEvents table does not contain a column named ConfigChangeType.

https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/mdcfileintegritymonitoringevents#columns

In the previously provided query example:
MDCFileIntegrityMonitoringEvents  
| where TimeGenerated > ago(14d)  
| where ConfigChangeType in ('Registry', 'Files')   | summarize count() by Computer, ConfigChangeType

The values 'Registry' and 'Files' assigned to ConfigChangeType should instead correspond to MonitoredEntityType, and the operation type should be represented by ChangeType. We kindly request that this query be corrected accordingly.