### PR TITLE
Update write-transaction-receipts.md

### DIFF
--- a/articles/confidential-ledger/write-transaction-receipts.md
+++ b/articles/confidential-ledger/write-transaction-receipts.md
@@ -223,7 +223,7 @@ The `receipt` field contains the following fields.
 
 The `leafComponents` field contains the following fields.
 
-* **claimsDigest**: Hexadecimal string representing the SHA-256 hash digest of the [application claim](https://microsoft.github.io/CCF/main/use_apps/verify_tx.html#application-claims) attached by the Confidential Ledger application at the time the transaction was executed. See [application claims](#application-claims)
+* **claimsDigest**: Hexadecimal string representing the SHA-256 hash digest of the [application claim](https://microsoft.github.io/CCF/main/use_apps/verify_tx.html#application-claims) attached by the Confidential Ledger application at the time the transaction was executed. To attach application claims, refer to the section [application claims](#application-claims) .
 
 * **commitEvidence**: A unique string produced per transaction, derived from the transaction ID and the ledger secrets. For more information about the commit evidence, see the related [CCF documentation](https://microsoft.github.io/CCF/main/use_apps/verify_tx.html#commit-evidence).
 

--- a/articles/confidential-ledger/write-transaction-receipts.md
+++ b/articles/confidential-ledger/write-transaction-receipts.md
@@ -223,7 +223,7 @@ The `receipt` field contains the following fields.
 
 The `leafComponents` field contains the following fields.
 
-* **claimsDigest**: Hexadecimal string representing the SHA-256 hash digest of the [application claim](https://microsoft.github.io/CCF/main/use_apps/verify_tx.html#application-claims) attached by the Confidential Ledger application at the time the transaction was executed. Application claims are currently unsupported as the Confidential Ledger application doesn't attach any claim when executing a write transaction.
+* **claimsDigest**: Hexadecimal string representing the SHA-256 hash digest of the [application claim](https://microsoft.github.io/CCF/main/use_apps/verify_tx.html#application-claims) attached by the Confidential Ledger application at the time the transaction was executed. See [application claims](#application-claims)
 
 * **commitEvidence**: A unique string produced per transaction, derived from the transaction ID and the ledger secrets. For more information about the commit evidence, see the related [CCF documentation](https://microsoft.github.io/CCF/main/use_apps/verify_tx.html#commit-evidence).
 


### PR DESCRIPTION
Removed old statement about unsupported Application Claims. This is now supported and documented in the same doc