### PR TITLE
Remove Azure Database for MariaDB from detection list

### DIFF
--- a/articles/defender-for-cloud/enable-defender-for-databases-azure.md
+++ b/articles/defender-for-cloud/enable-defender-for-databases-azure.md
@@ -14,7 +14,6 @@ Microsoft Defender for Cloud detects anomalous activities indicating unusual and
 
 - [Azure Database for PostgreSQL](/azure/postgresql/)
 - [Azure Database for MySQL](/azure/mysql/)
-- [Azure Database for MariaDB](/azure/mariadb/)
 
 To get alerts from the Microsoft Defender plan, you need to follow the instructions on this page to enable Defender for open-source relational databases Azure.
 


### PR DESCRIPTION
Removed Azure Database for MariaDB from the list of services detected by Microsoft Defender for Cloud.