### PR TITLE
Clarify permissions needed for changing RBAC model

### DIFF
--- a/articles/key-vault/general/rbac-guide.md
+++ b/articles/key-vault/general/rbac-guide.md
@@ -113,7 +113,8 @@ To manage role assignments, you must have `Microsoft.Authorization/roleAssignmen
 ### Enable Azure RBAC permissions on Key Vault
 
 > [!NOTE]
-> Changing the permission model requires unrestricted 'Microsoft.Authorization/roleAssignments/write' permission, which is part of the [Owner](/azure/role-based-access-control/built-in-roles#owner) and [User Access Administrator](/azure/role-based-access-control/built-in-roles#user-access-administrator) roles. Classic subscription administrator roles like 'Service Administrator' and 'Co-Administrator', or restricted 'Key Vault Data Access Administrator' cannot be used to change permission model.
+> Changing the permission model requires unrestricted 'Microsoft.Authorization/roleAssignments/write' permission, which is part of the [Owner](/azure/role-based-access-control/built-in-roles#owner) and [User Access Administrator](/azure/role-based-access-control/built-in-roles#user-access-administrator) roles. If using the latter, you will also need 'Microsoft.KeyVault/vaults/write' permission, which is part of [Key Vault Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/security#key-vault-contributor) role.
+Classic subscription administrator roles like 'Service Administrator' and 'Co-Administrator', or restricted 'Key Vault Data Access Administrator' cannot be used to change permission model.
 
 1. Enable Azure RBAC permissions on new key vault:
 


### PR DESCRIPTION
Added requirement for 'Microsoft.KeyVault/vaults/write' permission when using User Access Administrator role.